### PR TITLE
 Add support for 11ty pagination: false tag

### DIFF
--- a/utils/transforms.js
+++ b/utils/transforms.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
   config.addTransform('critical', critical)
 
   config.addTransform('format', function(content, outputPath) {
-    if (outputPath.endsWith('.html')) {
+    if (outputPath && outputPath.endsWith('.html')) {
       return minify.html(content)
     }
 

--- a/utils/transforms/append.js
+++ b/utils/transforms/append.js
@@ -1,7 +1,7 @@
 const { JSDOM } = require('jsdom')
 
 module.exports = async function(content, outputPath) {
-  if (outputPath.endsWith('.html')) {
+  if (outputPath && outputPath.endsWith('.html')) {
     const dom = new JSDOM(content)
     const { document } = dom.window
 

--- a/utils/transforms/critical.js
+++ b/utils/transforms/critical.js
@@ -5,7 +5,7 @@ const critical = require('critical')
 const twelvety = require('@12ty')
 
 module.exports = async function(content, outputPath) {
-  if (outputPath.endsWith('.html') && twelvety.env === 'production') {
+  if (outputPath && outputPath.endsWith('.html') && twelvety.env === 'production') {
     const { css } = await critical.generate({
       base: twelvety.dir.output,
       html: content,


### PR DESCRIPTION
11ty build fails if the `pagination:false` tag is used as `outputPath `will be undefined.  This fixes that error.