### PR TITLE
update picture quality options

### DIFF
--- a/utils/shortcodes/picture.js
+++ b/utils/shortcodes/picture.js
@@ -16,7 +16,9 @@ const SIZES = Array.from(new Array(12), (_, index) => (index + 1) * 160)
 const CACHE_FILE = path.join(process.cwd(), '.twelvety.cache')
 
 // Quality of outputted images
-const QUALITY = 75
+const SAMEQUALITY = 75
+const WEBPQUALITY = 60
+const AVIFQUALITY = 35
 
 // Function to deasync sharp functions
 // This is required for synchronous markdown-it plugin
@@ -52,10 +54,10 @@ function loadCache() {
 }
 
 // Save image as the given size and format
-function saveImageFormat(image, width, format) {
+function saveImageFormat(image, width, format, quality) {
   // Resize image and format with given quality
   const formatted = image.clone().resize(width)[format]({
-    quality: QUALITY
+    quality: quality
   })
 
   // Save buffer of formatted image
@@ -99,7 +101,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const sameFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.same.hasOwnProperty(width))
       ? cachePicture.same[width]
-      : saveImageFormat(original, width, format)
+      : saveImageFormat(original, width, format, SAMEQUALITY)
     return images
   }, {})
 
@@ -112,7 +114,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const webpFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.webp.hasOwnProperty(width))
       ? cachePicture.webp[width]
-      : saveImageFormat(original, width, 'webp')
+      : saveImageFormat(original, width, 'webp', WEBPQUALITY)
     return images
   }, {})
 
@@ -125,7 +127,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const avifFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.avif.hasOwnProperty(width))
       ? cachePicture.avif[width]
-      : saveImageFormat(original, width, 'avif')
+      : saveImageFormat(original, width, 'avif', AVIFQUALITY)
     return images
   }, {})
 

--- a/utils/shortcodes/picture.js
+++ b/utils/shortcodes/picture.js
@@ -16,9 +16,9 @@ const SIZES = Array.from(new Array(12), (_, index) => (index + 1) * 160)
 const CACHE_FILE = path.join(process.cwd(), '.twelvety.cache')
 
 // Quality of outputted images
-const SAMEQUALITY = 75
-const WEBPQUALITY = 60
-const AVIFQUALITY = 35
+const SAME_QUALITY = 75
+const WEBP_QUALITY = 60
+const AVIF_QUALITY = 35
 
 // Function to deasync sharp functions
 // This is required for synchronous markdown-it plugin
@@ -57,7 +57,7 @@ function loadCache() {
 function saveImageFormat(image, width, format, quality) {
   // Resize image and format with given quality
   const formatted = image.clone().resize(width)[format]({
-    quality: quality
+    quality
   })
 
   // Save buffer of formatted image
@@ -101,7 +101,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const sameFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.same.hasOwnProperty(width))
       ? cachePicture.same[width]
-      : saveImageFormat(original, width, format, SAMEQUALITY)
+      : saveImageFormat(original, width, format, SAME_QUALITY)
     return images
   }, {})
 
@@ -114,7 +114,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const webpFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.webp.hasOwnProperty(width))
       ? cachePicture.webp[width]
-      : saveImageFormat(original, width, 'webp', WEBPQUALITY)
+      : saveImageFormat(original, width, 'webp', WEBP_QUALITY)
     return images
   }, {})
 
@@ -127,7 +127,7 @@ module.exports = function(src, alt, sizes = '90vw, (min-width: 1280px) 1152px', 
   const avifFormat = SIZES.reduce((images, width) => {
     images[width] = (cachePicture && cachePicture.avif.hasOwnProperty(width))
       ? cachePicture.avif[width]
-      : saveImageFormat(original, width, 'avif', AVIFQUALITY)
+      : saveImageFormat(original, width, 'avif', AVIF_QUALITY)
     return images
   }, {})
 


### PR DESCRIPTION
Due to the higher quality of WebP and AVIF image formats, you can reduce the quality when creating the images. 

This current configuration creates images of comparable quality with the following sizes:

Image: Car with blurred dark background
Size: 1920 x 960

jpeg: 169 kb
webp: 58.9 kb
avif: 18.5 kb

